### PR TITLE
Fix for #54

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,11 @@
             <artifactId>commons-io</artifactId>
             <version>${commons.io.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.0</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -134,11 +134,6 @@
             <artifactId>commons-io</artifactId>
             <version>${commons.io.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.0</version>
-        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/com/ldbc/driver/OperationHandlerRunnableContext.java
+++ b/src/main/java/com/ldbc/driver/OperationHandlerRunnableContext.java
@@ -159,7 +159,8 @@ public class OperationHandlerRunnableContext implements Runnable, Poolable
                         operation.scheduledStartTimeAsMilli(),
                         resultReporter.actualStartTimeAsMilli(),
                         resultReporter.runDurationAsNano(),
-                        resultReporter.resultCode()
+                        resultReporter.resultCode(),
+                        operation.timeStamp()
                 );
             }
         }

--- a/src/main/java/com/ldbc/driver/client/ExecuteWorkloadMode.java
+++ b/src/main/java/com/ldbc/driver/client/ExecuteWorkloadMode.java
@@ -174,7 +174,8 @@ public class ExecuteWorkloadMode implements ClientMode<Object>
                         "scheduled_start_time_" + TimeUnit.MILLISECONDS.name(),
                         "actual_start_time_" + TimeUnit.MILLISECONDS.name(),
                         "execution_duration_" + controlService.configuration().timeUnit().name(),
-                        "result_code"
+                        "result_code",
+                        "original_start_time"
                 );
             }
             catch ( IOException e )

--- a/src/main/java/com/ldbc/driver/runtime/metrics/DisruptorJavolutionMetricsService.java
+++ b/src/main/java/com/ldbc/driver/runtime/metrics/DisruptorJavolutionMetricsService.java
@@ -213,7 +213,7 @@ public class DisruptorJavolutionMetricsService implements MetricsService
 
         @Override
         public void submitOperationResult( int operationType, long scheduledStartTimeAsMilli,
-                long actualStartTimeAsMilli, long runDurationAsNano, int resultCode ) throws MetricsCollectionException
+                long actualStartTimeAsMilli, long runDurationAsNano, int resultCode, long originalStartTime ) throws MetricsCollectionException
         {
             if ( null != alreadyShutdownPolicy )
             {
@@ -221,7 +221,7 @@ public class DisruptorJavolutionMetricsService implements MetricsService
             }
             initiatedEvents.incrementAndGet();
             ringBuffer.publishEvent( SET_AS_SUBMIT_OPERATION_RESULT, operationType, scheduledStartTimeAsMilli,
-                    actualStartTimeAsMilli, runDurationAsNano, resultCode );
+                    actualStartTimeAsMilli, runDurationAsNano, resultCode, originalStartTime );
         }
 
         @Override

--- a/src/main/java/com/ldbc/driver/runtime/metrics/DisruptorSbeMetricsEvent.java
+++ b/src/main/java/com/ldbc/driver/runtime/metrics/DisruptorSbeMetricsEvent.java
@@ -41,7 +41,7 @@ public class DisruptorSbeMetricsEvent {
 
         @Override
         public DirectBuffer newInstance() {
-            final ByteBuffer byteBuffer = ByteBuffer.allocateDirect(48);
+            final ByteBuffer byteBuffer = ByteBuffer.allocateDirect(64);
             DirectBuffer directBuffer = new DirectBuffer(byteBuffer);
             messageHeader.wrap(directBuffer, 0, MESSAGE_TEMPLATE_VERSION)
                     .blockLength(metricsEvent.sbeBlockLength())
@@ -62,6 +62,7 @@ public class DisruptorSbeMetricsEvent {
                 ", actualStartTimeAsMilli=" + metricsEvent.actualStartTimeAsMilli() +
                 ", runDurationAsNano=" + metricsEvent.runDurationAsNano() +
                 ", resultCode=" + metricsEvent.resultCode() +
+                ", originalStartTime=" + metricsEvent.originalStartTime() +
                 '}';
     }
 }

--- a/src/main/java/com/ldbc/driver/runtime/metrics/DisruptorSbeMetricsEventHandler.java
+++ b/src/main/java/com/ldbc/driver/runtime/metrics/DisruptorSbeMetricsEventHandler.java
@@ -87,6 +87,7 @@ class DisruptorSbeMetricsEventHandler implements EventHandler<DirectBuffer>
             long actualStartTimeAsMilli = metricsEvent.actualStartTimeAsMilli();
             long runDurationAsNano = metricsEvent.runDurationAsNano();
             int resultCode = metricsEvent.resultCode();
+            long originalStartTime = metricsEvent.originalStartTime();
 
             if ( null != csvResultsLogWriter )
             {
@@ -102,7 +103,8 @@ class DisruptorSbeMetricsEventHandler implements EventHandler<DirectBuffer>
                         Long.toString( scheduledStartTimeAsMilli ),
                         Long.toString( actualStartTimeAsMilli ),
                         Long.toString( unit.convert( runDurationAsNano, TimeUnit.NANOSECONDS ) ),
-                        Integer.toString( resultCode )
+                        Integer.toString( resultCode ),
+                        Long.toString(originalStartTime)
                 );
             }
             metricsManager.measure( actualStartTimeAsMilli, runDurationAsNano, operationType );

--- a/src/main/java/com/ldbc/driver/runtime/metrics/DisruptorSbeMetricsService.java
+++ b/src/main/java/com/ldbc/driver/runtime/metrics/DisruptorSbeMetricsService.java
@@ -223,7 +223,8 @@ public class DisruptorSbeMetricsService implements MetricsService
                 long scheduledStartTimeAsMilli,
                 long actualStartTimeAsMilli,
                 long runDurationAsNano,
-                int resultCode ) throws MetricsCollectionException
+                int resultCode,
+                long originalStartTime) throws MetricsCollectionException
         {
             if ( null != alreadyShutdownPolicy )
             {
@@ -231,7 +232,7 @@ public class DisruptorSbeMetricsService implements MetricsService
             }
             initiatedEvents.incrementAndGet();
             ringBuffer.publishEvent( submitOperationResultTranslator, operationType, scheduledStartTimeAsMilli,
-                    actualStartTimeAsMilli, runDurationAsNano, resultCode );
+                    actualStartTimeAsMilli, runDurationAsNano, resultCode, originalStartTime );
         }
 
         @Override
@@ -286,7 +287,8 @@ public class DisruptorSbeMetricsService implements MetricsService
                         .scheduledStartTimeAsMilli( (long) fields[1] )
                         .actualStartTimeAsMilli( (long) fields[2] )
                         .runDurationAsNano( (long) fields[3] )
-                        .resultCode( (int) fields[4] );
+                        .resultCode( (int) fields[4] )
+                        .originalStartTime((long) fields[5]);
             }
         }
 

--- a/src/main/java/com/ldbc/driver/runtime/metrics/MetricsService.java
+++ b/src/main/java/com/ldbc/driver/runtime/metrics/MetricsService.java
@@ -13,7 +13,8 @@ public interface MetricsService
                 long scheduledStartTimeAsMilli,
                 long actualStartTimeAsMilli,
                 long runDurationAsNano,
-                int resultCode ) throws MetricsCollectionException;
+                int resultCode,
+                long originalStartTime) throws MetricsCollectionException;
 
         WorkloadStatusSnapshot status() throws MetricsCollectionException;
 

--- a/src/main/java/com/ldbc/driver/runtime/metrics/ThreadedQueuedMetricsEvent.java
+++ b/src/main/java/com/ldbc/driver/runtime/metrics/ThreadedQueuedMetricsEvent.java
@@ -21,18 +21,21 @@ abstract class ThreadedQueuedMetricsEvent {
         private final long actualStartTimeAsMilli;
         private final long runDurationAsNano;
         private final int resultCode;
+        private final long originalStartTime;
 
         public SubmitOperationResult(
                 int operationType,
                 long scheduledStartTimeAsMilli,
                 long actualStartTimeAsMilli,
                 long runDurationAsNano,
-                int resultCode) {
+                int resultCode,
+                long originalStartTime) {
             this.operationType = operationType;
             this.scheduledStartTimeAsMilli = scheduledStartTimeAsMilli;
             this.actualStartTimeAsMilli = actualStartTimeAsMilli;
             this.runDurationAsNano = runDurationAsNano;
             this.resultCode = resultCode;
+            this.originalStartTime = originalStartTime;
         }
 
         public int operationType() {
@@ -53,6 +56,10 @@ abstract class ThreadedQueuedMetricsEvent {
 
         public int resultCode() {
             return resultCode;
+        }
+        
+        public long originalStartTime() {
+        	return originalStartTime;
         }
 
         @Override

--- a/src/main/java/com/ldbc/driver/runtime/metrics/ThreadedQueuedMetricsService.java
+++ b/src/main/java/com/ldbc/driver/runtime/metrics/ThreadedQueuedMetricsService.java
@@ -170,7 +170,7 @@ public class ThreadedQueuedMetricsService implements MetricsService
 
         @Override
         public void submitOperationResult( int operationType, long scheduledStartTimeAsMilli,
-                long actualStartTimeAsMilli, long runDurationAsNano, int resultCode ) throws MetricsCollectionException
+                long actualStartTimeAsMilli, long runDurationAsNano, int resultCode, long originalStartTime ) throws MetricsCollectionException
         {
             if ( null != alreadyShutdownPolicy )
             {
@@ -184,7 +184,8 @@ public class ThreadedQueuedMetricsService implements MetricsService
                         scheduledStartTimeAsMilli,
                         actualStartTimeAsMilli,
                         runDurationAsNano,
-                        resultCode
+                        resultCode,
+                        originalStartTime
                 );
                 queueEventSubmitter.submitEventToQueue( event );
             }
@@ -197,12 +198,14 @@ public class ThreadedQueuedMetricsService implements MetricsService
                         + "Actual Start Time Ms: %s\n"
                         + "Duration Ns: %s\n"
                         + "Result Code: %s\n"
+                        + "Original start time: %s\n"
                         ,
                         operationType,
                         scheduledStartTimeAsMilli,
                         actualStartTimeAsMilli,
                         runDurationAsNano,
-                        resultCode
+                        resultCode,
+                        originalStartTime
                 );
                 throw new MetricsCollectionException( errMsg, e );
             }

--- a/src/main/java/com/ldbc/driver/runtime/metrics/ThreadedQueuedMetricsServiceThread.java
+++ b/src/main/java/com/ldbc/driver/runtime/metrics/ThreadedQueuedMetricsServiceThread.java
@@ -109,7 +109,8 @@ public class ThreadedQueuedMetricsServiceThread extends Thread
                         Long.toString( submitOperationResultEvent.actualStartTimeAsMilli() ),
                         Long.toString(
                                 unit.convert( submitOperationResultEvent.runDurationAsNano(), TimeUnit.NANOSECONDS ) ),
-                        Integer.toString( submitOperationResultEvent.resultCode() )
+                        Integer.toString( submitOperationResultEvent.resultCode() ),
+                        Long.toString( submitOperationResultEvent.originalStartTime() )
                 );
             }
 
@@ -132,12 +133,14 @@ public class ThreadedQueuedMetricsServiceThread extends Thread
                                 + "Actual Start Time Ms: %s\n"
                                 + "Duration Ns: %s\n"
                                 + "Result Code: %s\n"
+                                + "Original start time: %s\n"
                                 ,
                                 submitOperationResultEvent.operationType(),
                                 submitOperationResultEvent.scheduledStartTimeAsMilli(),
                                 submitOperationResultEvent.actualStartTimeAsMilli(),
                                 submitOperationResultEvent.runDurationAsNano(),
                                 submitOperationResultEvent.resultCode(),
+                                submitOperationResultEvent.originalStartTime(),
                                 ConcurrentErrorReporter.stackTraceToString( e )
                         )
                 );

--- a/src/main/java/com/ldbc/driver/runtime/metrics/sbe/MetricsEvent.java
+++ b/src/main/java/com/ldbc/driver/runtime/metrics/sbe/MetricsEvent.java
@@ -5,7 +5,7 @@ import uk.co.real_logic.sbe.codec.java.*;
 
 public class MetricsEvent
 {
-    public static final int BLOCK_LENGTH = 33;
+    public static final int BLOCK_LENGTH = 41;
     public static final int TEMPLATE_ID = 1;
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
@@ -341,6 +341,17 @@ public class MetricsEvent
     public MetricsEvent resultCode(final int value)
     {
         CodecUtil.int32Put(buffer, offset + 29, value, java.nio.ByteOrder.LITTLE_ENDIAN);
+        return this;
+    }
+    
+    public long originalStartTime()
+    {
+    	return CodecUtil.int64Get(buffer, offset + 33, java.nio.ByteOrder.LITTLE_ENDIAN);
+    }
+    
+    public MetricsEvent originalStartTime(final long value)
+    {
+        CodecUtil.int64Put(buffer, offset + 33, value, java.nio.ByteOrder.LITTLE_ENDIAN);
         return this;
     }
 }

--- a/src/main/java/com/ldbc/driver/runtime/metrics/sbe/MetricsEvent.java
+++ b/src/main/java/com/ldbc/driver/runtime/metrics/sbe/MetricsEvent.java
@@ -343,12 +343,44 @@ public class MetricsEvent
         CodecUtil.int32Put(buffer, offset + 29, value, java.nio.ByteOrder.LITTLE_ENDIAN);
         return this;
     }
-    
+
+    public static int originalStartTimeId()
+    {
+        return 7;
+    }
+
+    public static String originalStartTimeMetaAttribute(final MetaAttribute metaAttribute)
+    {
+        switch (metaAttribute)
+        {
+            case EPOCH: return "unix";
+            case TIME_UNIT: return "nanosecond";
+            case SEMANTIC_TYPE: return "";
+        }
+
+        return "";
+    }
+
+    public static long originalStartTimeNullValue()
+    {
+        return -9223372036854775808L;
+    }
+
+    public static long originalStartTimeMinValue()
+    {
+        return -9223372036854775807L;
+    }
+
+    public static long originalStartTimeMaxValue()
+    {
+        return 9223372036854775807L;
+    }
+
     public long originalStartTime()
     {
-    	return CodecUtil.int64Get(buffer, offset + 33, java.nio.ByteOrder.LITTLE_ENDIAN);
+        return CodecUtil.int64Get(buffer, offset + 33, java.nio.ByteOrder.LITTLE_ENDIAN);
     }
-    
+
     public MetricsEvent originalStartTime(final long value)
     {
         CodecUtil.int64Put(buffer, offset + 33, value, java.nio.ByteOrder.LITTLE_ENDIAN);

--- a/src/main/resources/metrics-schema.xml
+++ b/src/main/resources/metrics-schema.xml
@@ -21,5 +21,6 @@
         <field name="actualStartTimeAsMilli" id="4" type="int64"/>
         <field name="runDurationAsNano" id="5" type="int64"/>
         <field name="resultCode" id="6" type="int32"/>
+        <field name="originalStartTime" id="7" type="int64"/>
     </sbe:message>
 </sbe:messageSchema>

--- a/src/test/java/com/ldbc/driver/runtime/metrics/DisruptorJavolutionMetricsServiceTest.java
+++ b/src/test/java/com/ldbc/driver/runtime/metrics/DisruptorJavolutionMetricsServiceTest.java
@@ -100,7 +100,7 @@ public class DisruptorJavolutionMetricsServiceTest
         long operation1RunDuration = TimeUnit.MILLISECONDS.toNanos( 1 );
 
         metricsServiceWriter.submitOperationResult( operation1.type(), operation1.scheduledStartTimeAsMilli(),
-                operation1ActualStartTime, operation1RunDuration, operation1ResultCode );
+                operation1ActualStartTime, operation1RunDuration, operation1ResultCode, operation1.timeStamp() );
 
         assertThat( metricsServiceWriter.results().startTimeAsMilli(), equalTo( 2l ) );
         assertThat( metricsServiceWriter.results().latestFinishTimeAsMilli(), equalTo( 3l ) );
@@ -113,7 +113,7 @@ public class DisruptorJavolutionMetricsServiceTest
         long operation2RunDuration = TimeUnit.MILLISECONDS.toNanos( 3 );
 
         metricsServiceWriter.submitOperationResult( operation2.type(), operation2.scheduledStartTimeAsMilli(),
-                operation2ActualStartTime, operation2RunDuration, operation2ResultCode );
+                operation2ActualStartTime, operation2RunDuration, operation2ResultCode, operation2.timeStamp() );
 
         assertThat( metricsServiceWriter.results().startTimeAsMilli(), equalTo( 2l ) );
         assertThat( metricsServiceWriter.results().latestFinishTimeAsMilli(), equalTo( 11l ) );
@@ -126,7 +126,7 @@ public class DisruptorJavolutionMetricsServiceTest
         long operation3RunDuration = TimeUnit.MILLISECONDS.toNanos( 5 );
 
         metricsServiceWriter.submitOperationResult( operation3.type(), operation3.scheduledStartTimeAsMilli(),
-                operation3ActualStartTime, operation3RunDuration, operation3ResultCode );
+                operation3ActualStartTime, operation3RunDuration, operation3ResultCode, operation3.timeStamp() );
 
         WorkloadResultsSnapshot results = metricsServiceWriter.results();
         assertThat( results.startTimeAsMilli(), equalTo( 2l ) );

--- a/src/test/java/com/ldbc/driver/runtime/metrics/DisruptorSbeMetricsServiceTest.java
+++ b/src/test/java/com/ldbc/driver/runtime/metrics/DisruptorSbeMetricsServiceTest.java
@@ -99,7 +99,7 @@ public class DisruptorSbeMetricsServiceTest
         long operation1RunDuration = TimeUnit.MILLISECONDS.toNanos( 1 );
 
         metricsServiceWriter.submitOperationResult( operation1.type(), operation1.scheduledStartTimeAsMilli(),
-                operation1ActualStartTime, operation1RunDuration, operation1ResultCode );
+                operation1ActualStartTime, operation1RunDuration, operation1ResultCode, operation1.timeStamp() );
 
         assertThat( metricsServiceWriter.results().startTimeAsMilli(), equalTo( 2l ) );
         assertThat( metricsServiceWriter.results().latestFinishTimeAsMilli(), equalTo( 3l ) );
@@ -112,7 +112,7 @@ public class DisruptorSbeMetricsServiceTest
         long operation2RunDuration = TimeUnit.MILLISECONDS.toNanos( 3 );
 
         metricsServiceWriter.submitOperationResult( operation2.type(), operation2.scheduledStartTimeAsMilli(),
-                operation2ActualStartTime, operation2RunDuration, operation2ResultCode );
+                operation2ActualStartTime, operation2RunDuration, operation2ResultCode, operation2.timeStamp() );
 
         assertThat( metricsServiceWriter.results().startTimeAsMilli(), equalTo( 2l ) );
         assertThat( metricsServiceWriter.results().latestFinishTimeAsMilli(), equalTo( 11l ) );
@@ -125,7 +125,7 @@ public class DisruptorSbeMetricsServiceTest
         long operation3RunDuration = TimeUnit.MILLISECONDS.toNanos( 5 );
 
         metricsServiceWriter.submitOperationResult( operation3.type(), operation3.scheduledStartTimeAsMilli(),
-                operation3ActualStartTime, operation3RunDuration, operation3ResultCode );
+                operation3ActualStartTime, operation3RunDuration, operation3ResultCode, operation3.timeStamp() );
 
         WorkloadResultsSnapshot results = metricsServiceWriter.results();
         assertThat( results.startTimeAsMilli(), equalTo( 2l ) );

--- a/src/test/java/com/ldbc/driver/runtime/metrics/DummyCountingMetricsService.java
+++ b/src/test/java/com/ldbc/driver/runtime/metrics/DummyCountingMetricsService.java
@@ -19,7 +19,8 @@ public class DummyCountingMetricsService implements MetricsService, MetricsServi
                                       long scheduledStartTimeAsMilli,
                                       long actualStartTimeAsMilli,
                                       long runDurationAsNano,
-                                      int resultCode) throws MetricsCollectionException {
+                                      int resultCode,
+                                      long originalStartTime) throws MetricsCollectionException {
         count++;
     }
 

--- a/src/test/java/com/ldbc/driver/runtime/metrics/MetricsManagerPerformanceTest.java
+++ b/src/test/java/com/ldbc/driver/runtime/metrics/MetricsManagerPerformanceTest.java
@@ -496,7 +496,8 @@ public class MetricsManagerPerformanceTest
                     startTime,
                     startTime,
                     duration,
-                    resultCode
+                    resultCode,
+                    startTime
             );
             // do nothing
         }
@@ -543,7 +544,8 @@ public class MetricsManagerPerformanceTest
                     startTime,
                     startTime,
                     duration,
-                    resultCode
+                    resultCode,
+                    startTime
             );
             metricsServiceThread.onEvent( event );
         }
@@ -586,7 +588,7 @@ public class MetricsManagerPerformanceTest
             int operationTypeIndex = startTime % operationTypeCount;
             long duration = durations[startTime % highestExpectedRuntimeDurationAsNano];
             int operationType = operationTypes[operationTypeIndex];
-            metricsServiceWriter.submitOperationResult( operationType, startTime, startTime, duration, resultCode );
+            metricsServiceWriter.submitOperationResult( operationType, startTime, startTime, duration, resultCode, startTime );
         }
         final WorkloadResultsSnapshot snapshot = metricsServiceWriter.results();
         final long benchmarkFinishTime = System.currentTimeMillis();
@@ -631,7 +633,7 @@ public class MetricsManagerPerformanceTest
             int operationTypeIndex = startTime % operationTypeCount;
             long duration = durations[startTime % highestExpectedRuntimeDurationAsNano];
             int operationType = operationTypes[operationTypeIndex];
-            metricsServiceWriter.submitOperationResult( operationType, startTime, startTime, duration, resultCode );
+            metricsServiceWriter.submitOperationResult( operationType, startTime, startTime, duration, resultCode, startTime );
         }
         final WorkloadResultsSnapshot snapshot = metricsServiceWriter.results();
         final long benchmarkFinishTime = System.currentTimeMillis();
@@ -676,7 +678,7 @@ public class MetricsManagerPerformanceTest
             int operationTypeIndex = startTime % operationTypeCount;
             long duration = durations[startTime % highestExpectedRuntimeDurationAsNano];
             int operationType = operationTypes[operationTypeIndex];
-            metricsServiceWriter.submitOperationResult( operationType, startTime, startTime, duration, resultCode );
+            metricsServiceWriter.submitOperationResult( operationType, startTime, startTime, duration, resultCode, startTime );
         }
         final WorkloadResultsSnapshot snapshot = metricsServiceWriter.results();
         final long benchmarkFinishTime = System.currentTimeMillis();
@@ -892,7 +894,7 @@ public class MetricsManagerPerformanceTest
                 try
                 {
                     metricsServiceWriter
-                            .submitOperationResult( operationType, startTime, startTime, duration, resultCode );
+                            .submitOperationResult( operationType, startTime, startTime, duration, resultCode, startTime );
                 }
                 catch ( MetricsCollectionException e )
                 {

--- a/src/test/java/com/ldbc/driver/runtime/metrics/ThreadedQueuedMetricsServiceTest.java
+++ b/src/test/java/com/ldbc/driver/runtime/metrics/ThreadedQueuedMetricsServiceTest.java
@@ -166,7 +166,7 @@ public class ThreadedQueuedMetricsServiceTest
         long operation1RunDuration = TimeUnit.MILLISECONDS.toNanos( 1 );
 
         metricsServiceWriter.submitOperationResult( operation1.type(), operation1.scheduledStartTimeAsMilli(),
-                operation1ActualStartTime, operation1RunDuration, operation1ResultCode );
+                operation1ActualStartTime, operation1RunDuration, operation1ResultCode, operation1.timeStamp() );
 
         assertThat( metricsServiceWriter.results().startTimeAsMilli(), equalTo( 2l ) );
         assertThat( metricsServiceWriter.results().latestFinishTimeAsMilli(), equalTo( 3l ) );
@@ -179,7 +179,7 @@ public class ThreadedQueuedMetricsServiceTest
         long operation2RunDuration = TimeUnit.MILLISECONDS.toNanos( 3 );
 
         metricsServiceWriter.submitOperationResult( operation2.type(), operation2.scheduledStartTimeAsMilli(),
-                operation2ActualStartTime, operation2RunDuration, operation2ResultCode );
+                operation2ActualStartTime, operation2RunDuration, operation2ResultCode, operation2.timeStamp() );
 
         assertThat( metricsServiceWriter.results().startTimeAsMilli(), equalTo( 2l ) );
         assertThat( metricsServiceWriter.results().latestFinishTimeAsMilli(), equalTo( 11l ) );
@@ -192,7 +192,7 @@ public class ThreadedQueuedMetricsServiceTest
         long operation3RunDuration = TimeUnit.MILLISECONDS.toNanos( 5 );
 
         metricsServiceWriter.submitOperationResult( operation3.type(), operation3.scheduledStartTimeAsMilli(),
-                operation3ActualStartTime, operation3RunDuration, operation3ResultCode );
+                operation3ActualStartTime, operation3RunDuration, operation3ResultCode, operation3.timeStamp() );
 
         WorkloadResultsSnapshot results = metricsServiceWriter.results();
         assertThat( results.startTimeAsMilli(), equalTo( 2l ) );


### PR DESCRIPTION
Added column containing original start time to csv result log so that it can be correlated with the update stream files

This commit fixes #54. All tests pass

